### PR TITLE
정적 파일 호스팅 서버 주소 환경 변수화

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,2 @@
 export const appNameEnglish = "TagTree";
 export const appNameKorean = "태그트리";
-export const basementUrl = "https://tagtree-project.github.io/tagtree-basement"

--- a/src/data/api/apis.ts
+++ b/src/data/api/apis.ts
@@ -6,7 +6,6 @@ import {
   PagingInfoDTO,
 } from "@/data/api/dtos";
 import { supabase } from "@/data/api/supabase/supabase";
-import { basementUrl } from "@/constants";
 
 const pageSize = 15;
 
@@ -42,5 +41,5 @@ export const getTagInfosRelatedWithMarkdown = async (markdownId: string): Promis
 
 export const getMarkdownContent = async (markdownId: string): Promise<string | undefined> => {
   const meta = await getMarkdownMeta(markdownId);
-  return meta && await fetch(`${basementUrl}/markdowns/${meta.file_name}`).then(res => res.text());
+  return meta && await fetch(`${process.env.BASEMENT_SERVER_URL}/markdowns/${meta.file_name}`).then(res => res.text());
 }


### PR DESCRIPTION
다음은 이 작업을 수행한 Jules의 코멘트이다.

> I've removed it from `src/constants.ts` and updated `src/data/api/apis.ts` to use `process.env.BASEMENT_SERVER_URL` for fetching markdown content.
